### PR TITLE
fix: replace bare except with except Exception in nmap.py

### DIFF
--- a/app/utils/nmap.py
+++ b/app/utils/nmap.py
@@ -782,7 +782,7 @@ class PortScannerAsync(object):
         """
         try:
             return self._process.is_alive()
-        except:
+        except Exception:
             return False
 
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except Exception:` in `app/utils/nmap.py` (line 785). Bare excepts catch all exceptions including `SystemExit` and `KeyboardInterrupt`, which should generally propagate.

**Change:**
```python
# Before
except:
    return False

# After
except Exception:
    return False
```

## Testing
No behavior change for normal exceptions — style/correctness fix per PEP 8.